### PR TITLE
Change spelling of Kathmandu from Katmandu

### DIFF
--- a/src/timezones.json
+++ b/src/timezones.json
@@ -180,7 +180,7 @@
   "(GMT+05:00) Tashkent": "Asia/Tashkent",
   "(GMT+05:30) Colombo": "Asia/Colombo",
   "(GMT+05:30) India Standard Time": "Asia/Calcutta",
-  "(GMT+05:45) Katmandu": "Asia/Katmandu",
+  "(GMT+05:45) Kathmandu": "Asia/Kathmandu",
   "(GMT+06:00) Almaty": "Asia/Almaty",
   "(GMT+06:00) Bishkek": "Asia/Bishkek",
   "(GMT+06:00) Chagos": "Indian/Chagos",


### PR DESCRIPTION
Capital of Nepal is spelled Kathmandu and not Katmandu. It confuses us when we use this node module in our app, so better to use Kathmandu. 
Please accept this request.