### PR TITLE
Expose full zone to onChange callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ export default class TimezonePicker extends React.Component {
     });
 
     if (this.props.onChange) {
-      this.props.onChange(this.props.timezones[zone]);
+      this.props.onChange(this.props.timezones[zone], zone);
     } else {
       this.field.value = zone;
       this.setState({ value: zone });


### PR DESCRIPTION
Rational: I needed the number offset and didn't want to duplicate a lookup table of any sort.